### PR TITLE
Fix Julia compatibility bounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        julia-version:
+          - '1.10'
+          - '1'
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -8,5 +8,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [compat]
-LinearAlgebra = "1.11.0"
+LinearAlgebra = "1"
 MathOptInterface = "1"
+julia = "1.10"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,4 @@
 [deps]
-AmplNLWriter = "7c4d4715-977e-5154-bfe0-e096adeac482"
-Bonmin_jll = "29cba6d7-6840-5cf2-a2fa-9bdfccfe29ea"
-JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 ToQUIO = "c8c7c8a1-01ab-43fa-b80d-8804f80d4aae"

--- a/test/examples/solver_backed.jl
+++ b/test/examples/solver_backed.jl
@@ -1,0 +1,58 @@
+using Random
+using JuMP
+using ToQUIO
+
+using AmplNLWriter
+using Bonmin_jll
+const Bonmin_Optimizer = () -> AmplNLWriter.Optimizer(Bonmin_jll.amplexe)
+
+function test_example(;
+    m::Integer = 1, # number of equalities
+    k::Integer = 2, # number of inequalities
+    n::Integer = 4, # number of variables
+    seed::Integer = 0,
+)
+    Random.seed!(seed)
+
+    A = rand(-3:3, m, n)
+    b = rand(-3:3, m)
+
+    C = rand(-3:3, k, n)
+    d = rand(0:3, k)
+
+    model = Model()
+
+    @variable(model, -5 <= x[1:n] <= 10, Int)
+
+    # @objective(model, Min, sum(i * j * (-1)^(i + j) * x[i] * x[j] for i = 1:n for j = 1:n))
+    @objective(model, Min, sum(x))
+
+    @constraint(model, A * x .== b)
+    @constraint(model, C * x .<= d)
+
+    set_optimizer(model, () -> ToQUIO.Optimizer(Bonmin_Optimizer))
+
+    optimize!(model)
+
+    print(model)
+
+    @show termination_status(model)
+
+    if result_count(model) > 0
+        @show objective_value(model)
+        @show value.(x)
+    end
+
+    set_optimizer(model, Bonmin_Optimizer)
+
+    optimize!(model)
+
+    @show termination_status(model)
+
+    if result_count(model) > 0
+        @show objective_value(model)
+        @show value.(x)
+    end
+
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,60 +1,6 @@
 using Test
-using Random
-using JuMP
 using ToQUIO
 
-using AmplNLWriter
-using Bonmin_jll
-const Bonmin_Optimizer = () -> AmplNLWriter.Optimizer(Bonmin_jll.amplexe)
-
-function test_example(;
-    m::Integer = 1, # number of equalities
-    k::Integer = 2, # number of inequalities
-    n::Integer = 4, # number of variables
-    seed::Integer = 0,
-)
-    Random.seed!(seed)
-
-    A = rand(-3:3, m, n)
-    b = rand(-3:3, m)
-
-    C = rand(-3:3, k, n)
-    d = rand(0:3, k)
-
-    model = Model()
-
-    @variable(model, -5 <= x[1:n] <= 10, Int)
-
-    # @objective(model, Min, sum(i * j * (-1)^(i + j) * x[i] * x[j] for i = 1:n for j = 1:n))
-    @objective(model, Min, sum(x))
-
-    @constraint(model, A * x .== b)
-    @constraint(model, C * x .<= d)
-
-    set_optimizer(model, () -> ToQUIO.Optimizer(Bonmin_Optimizer))
-
-    optimize!(model)
-
-    print(model)
-
-    @show termination_status(model)
-
-    if result_count(model) > 0
-        @show objective_value(model)
-        @show value.(x)
-    end
-
-    set_optimizer(model, Bonmin_Optimizer)
-
-    optimize!(model)
-
-    @show termination_status(model)
-
-    if result_count(model) > 0
-        @show objective_value(model)
-        @show value.(x)
-    end
-
-    return nothing
+@testset "ToQUIO" begin
+    include("unit/compat.jl")
 end
-

--- a/test/unit/compat.jl
+++ b/test/unit/compat.jl
@@ -1,0 +1,10 @@
+using TOML
+
+@testset "Root compat policy" begin
+    project = TOML.parsefile(joinpath(pkgdir(ToQUIO), "Project.toml"))
+    compat = project["compat"]
+
+    @test compat["julia"] == "1.10"
+    @test compat["LinearAlgebra"] == "1"
+    @test compat["MathOptInterface"] == "1"
+end


### PR DESCRIPTION
Summary

- Adds an explicit Julia compat bound of `julia = "1.10"`.
- Relaxes the `LinearAlgebra` stdlib compat from `1.11.0` to `1`.
- Adds a TOML-based regression test for the root compat policy.
- Adds Ubuntu CI coverage for Julia `1.10` and Julia `1` using Julia Actions.
- Moves the previous solver-backed helper out of the default test entrypoint so compat tests do not require Bonmin or AmplNLWriter.

Tests

- Passed: `JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_DEPOT_PATH=/tmp/toquio-test-110:/home/bernalde/.julia /home/bernalde/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/bin/julia --startup-file=no --compiled-modules=no --pkgimages=no --project=. -e 'using Pkg; Pkg.test(; julia_args=\`--compiled-modules=no --pkgimages=no\`)'`
  - Result: `ToQUIO | 3 pass / 3 total`
- Passed: `JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_DEPOT_PATH=/tmp/toquio-test-112-final:/home/bernalde/.julia /home/bernalde/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia --startup-file=no --compiled-modules=no --pkgimages=no --project=. -e 'using Pkg; Pkg.test(; julia_args=\`--compiled-modules=no --pkgimages=no\`)'`
  - Result: `ToQUIO | 3 pass / 3 total`
- Passed: `JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_DEPOT_PATH=/tmp/toquio-url-110:/home/bernalde/.julia /home/bernalde/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/bin/julia --startup-file=no --compiled-modules=no --pkgimages=no -e 'using Pkg; Pkg.activate(; temp=true); Pkg.add(url="https://github.com/SECQUOIA/ToQUIO.jl", rev="fix/issue-4-julia-compat-bounds")'`
- Passed: `JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_DEPOT_PATH=/tmp/toquio-url-111:/home/bernalde/.julia /home/bernalde/.julia/juliaup/julia-1.11.9+0.x64.linux.gnu/bin/julia --startup-file=no --compiled-modules=no --pkgimages=no -e 'using Pkg; Pkg.activate(; temp=true); Pkg.add(url="https://github.com/SECQUOIA/ToQUIO.jl", rev="fix/issue-4-julia-compat-bounds")'`
- Passed: `JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_DEPOT_PATH=/tmp/toquio-url-112:/home/bernalde/.julia /home/bernalde/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia --startup-file=no --compiled-modules=no --pkgimages=no -e 'using Pkg; Pkg.activate(; temp=true); Pkg.add(url="https://github.com/SECQUOIA/ToQUIO.jl", rev="fix/issue-4-julia-compat-bounds")'`

Notes

- The `Pkg.add(url=..., rev=...)` checks use this branch because the fix is not on `main` until merge. After merge, the plain `Pkg.add(url="https://github.com/SECQUOIA/ToQUIO.jl")` path will resolve against the same compat policy.
- Local package tests disabled compiled modules and package images because Julia `1.10.11` hit a local `lld` package-image crash during precompilation. CI runs the normal Julia Actions build and test steps.

Closes #4
