### PR TITLE
Add Julia coverage upload to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,7 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v6
+        with:
+          files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,4 @@ jobs:
       - uses: codecov/codecov-action@v6
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Process Julia coverage output in CI with `julia-actions/julia-processcoverage@v1`.
- Upload `lcov.info` with `codecov/codecov-action@v6`.

## Tests

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'`
- `julia --project=. -e 'using Pkg; Pkg.test()'`

Closes #7.
