### PR TITLE
Add Dependabot dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    groups:
+      docs-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/test/unit/maintenance.jl
+++ b/test/unit/maintenance.jl
@@ -233,6 +233,7 @@ end
         config = read(dependabot_config, String)
 
         @test has_julia_dependabot_entry(config, "/")
+        @test has_julia_dependabot_entry(config, "/docs")
         @test has_github_actions_dependabot_entry(config)
     else
         # Dormant until #8 adds a Dependabot config; synthetic tests below


### PR DESCRIPTION
Summary:
- Add `.github/dependabot.yml` for weekly root Julia dependency updates.
- Add weekly docs Julia dependency updates because `docs/Project.toml` has its own `[compat]`.
- Add monthly GitHub Actions dependency updates now that workflows exist.
- Keep `/test` excluded because `test/Project.toml` intentionally has no separate `[compat]`.
- Extend maintenance tests to assert the docs Dependabot entry.

Tests:
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'` passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` passed, 50 tests.

Closes #8
