### PR TITLE
Add release workflow for General registration

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,25 @@
+name: TagBot
+
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: read
+
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.SSH_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thank you for your interest in contributing to ToQUIO.jl! This document provides
 - [Code Style](#code-style)
 - [Testing](#testing)
 - [Pull Request Process](#pull-request-process)
+- [Release Process](#release-process)
 - [Architecture Overview](#architecture-overview)
 
 ## Getting Started
@@ -217,6 +218,40 @@ Aim for high test coverage, especially for:
 - Maintainers will review your PR
 - Address any feedback or requested changes
 - Once approved, your PR will be merged
+
+## Release Process
+
+ToQUIO.jl is intended to be registered in the Julia General registry. Until the
+first registration is accepted and tagged, users should install the package by
+URL as shown in the README.
+
+Registered releases use JuliaRegistrator and TagBot:
+
+1. Confirm `Project.toml` has the intended version value. The first
+   registration should remain `version = "0.1.0"` unless a feature or breaking
+   change lands first.
+2. Run the package tests from the root environment:
+   ```julia
+   using Pkg
+   Pkg.test()
+   ```
+3. Build the documentation locally when release-facing docs changed:
+   ```bash
+   julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'
+   julia --project=docs docs/make.jl --skip-deploy
+   ```
+4. On the release commit, open a JuliaRegistrator request by commenting
+   `@JuliaRegistrator register`.
+5. After registration is accepted, confirm TagBot creates the matching tag and
+   GitHub release for the `Project.toml` version.
+
+Release checklist:
+
+- Confirm `Project.toml` version and compat bounds are correct.
+- Run the full package test suite.
+- Build documentation when docs changed.
+- Start JuliaRegistrator registration from the release commit.
+- Confirm TagBot created the tag and release.
 
 ## Architecture Overview
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,11 +245,18 @@ Registered releases use JuliaRegistrator and TagBot:
 5. After registration is accepted, confirm TagBot creates the matching tag and
    GitHub release for the `Project.toml` version.
 
+TagBot is configured with `ssh: ${{ secrets.SSH_KEY }}` so TagBot-created tags
+can trigger downstream workflows such as documentation deployment. If that
+secret is not configured before a release, confirm the tag and release were
+created, then run the documentation workflow manually with `workflow_dispatch`.
+
 Release checklist:
 
 - Confirm `Project.toml` version and compat bounds are correct.
 - Run the full package test suite.
 - Build documentation when docs changed.
+- Confirm the `SSH_KEY` secret is configured, or plan a manual documentation
+  deployment with `workflow_dispatch`.
 - Start JuliaRegistrator registration from the release commit.
 - Confirm TagBot created the tag and release.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ A Julia package that reformulates constrained integer optimization problems into
 
 ## Installation
 
-ToQUIO.jl is a Julia package. To install it, open a Julia REPL and run:
+ToQUIO.jl is targeting registration in the Julia General registry. Until the
+first registered release is accepted and tagged, install it by URL from a Julia
+REPL:
 
 ```julia
 using Pkg
@@ -35,6 +37,13 @@ Or from the Julia package manager (press `]`):
 
 ```julia
 pkg> add https://github.com/SECQUOIA/ToQUIO.jl
+```
+
+After registration, released versions will be installable with:
+
+```julia
+using Pkg
+Pkg.add("ToQUIO")
 ```
 
 ## Quick Start
@@ -273,6 +282,13 @@ ToQUIO.jl/
 ### Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+### Release State
+
+ToQUIO.jl is on the Julia General registration path rather than a permanent
+URL-only release path. The initial registration/tag should use
+`version = "0.1.0"` from `Project.toml` unless a feature or breaking change
+requires a version bump before registration.
 
 ## References
 

--- a/test/unit/maintenance.jl
+++ b/test/unit/maintenance.jl
@@ -12,6 +12,7 @@ const DOCS_PROJECT_DEPS = Dict(
 )
 
 const SUPPORTED_JULIA_VERSIONS = ("1.10", "1")
+const INITIAL_REGISTRATION_VERSION = "0.1.0"
 
 function normalized_yaml_scalar(value::AbstractString)
     value = strip(value)
@@ -147,9 +148,44 @@ has_github_actions_dependabot_entry(config::AbstractString) =
     project = TOML.parsefile(joinpath(pkgdir(ToQUIO), "Project.toml"))
     compat = project["compat"]
 
+    @test project["version"] == INITIAL_REGISTRATION_VERSION
     @test compat["julia"] == first(SUPPORTED_JULIA_VERSIONS)
     @test compat["LinearAlgebra"] == "1"
     @test compat["MathOptInterface"] == "1"
+end
+
+@testset "Release workflow policy" begin
+    tagbot_workflow = joinpath(pkgdir(ToQUIO), ".github", "workflows", "TagBot.yml")
+    @test isfile(tagbot_workflow)
+
+    tagbot_config = read(tagbot_workflow, String)
+    @test occursin(r"(?m)^\s*issue_comment\s*:", tagbot_config)
+    @test occursin(r"(?m)^\s*workflow_dispatch\s*:", tagbot_config)
+    @test occursin(r"(?m)^\s*contents:\s*write\s*$", tagbot_config)
+    @test occursin(r"(?m)^\s*issues:\s*read\s*$", tagbot_config)
+    @test occursin("github.actor == 'JuliaTagBot'", tagbot_config)
+    @test occursin("JuliaRegistries/TagBot@v1", tagbot_config)
+    @test occursin(raw"token: ${{ secrets.GITHUB_TOKEN }}", tagbot_config)
+    @test occursin(raw"ssh: ${{ secrets.SSH_KEY }}", tagbot_config)
+end
+
+@testset "Release documentation policy" begin
+    readme = read(joinpath(pkgdir(ToQUIO), "README.md"), String)
+    contributing = read(joinpath(pkgdir(ToQUIO), "CONTRIBUTING.md"), String)
+
+    @test occursin("targeting registration in the Julia General registry", readme)
+    @test occursin("After registration, released versions will be installable", readme)
+    @test occursin("""Pkg.add("ToQUIO")""", readme)
+    @test occursin("version = \"$(INITIAL_REGISTRATION_VERSION)\"", readme)
+
+    @test occursin("## Release Process", contributing)
+    @test occursin("JuliaRegistrator", contributing)
+    @test occursin("TagBot", contributing)
+    @test occursin("@JuliaRegistrator register", contributing)
+    @test occursin("Release checklist", contributing)
+    @test occursin("Pkg.test()", contributing)
+    @test occursin("docs/make.jl --skip-deploy", contributing)
+    @test occursin("version = \"$(INITIAL_REGISTRATION_VERSION)\"", contributing)
 end
 
 @testset "CI workflow policy" begin

--- a/test/unit/maintenance.jl
+++ b/test/unit/maintenance.jl
@@ -12,6 +12,7 @@ const DOCS_PROJECT_DEPS = Dict(
 )
 
 const SUPPORTED_JULIA_VERSIONS = ("1.10", "1")
+# Keep this in sync with Project.toml until the first registered tag is cut.
 const INITIAL_REGISTRATION_VERSION = "0.1.0"
 
 function normalized_yaml_scalar(value::AbstractString)
@@ -182,6 +183,8 @@ end
     @test occursin("JuliaRegistrator", contributing)
     @test occursin("TagBot", contributing)
     @test occursin("@JuliaRegistrator register", contributing)
+    @test occursin("SSH_KEY", contributing)
+    @test occursin("workflow_dispatch", contributing)
     @test occursin("Release checklist", contributing)
     @test occursin("Pkg.test()", contributing)
     @test occursin("docs/make.jl --skip-deploy", contributing)


### PR DESCRIPTION
## Summary

- Choose the Julia General registration path for ToQUIO.jl while keeping URL installation documented until the first registered release lands.
- Add a TagBot workflow for JuliaRegistrator-driven tags and releases.
- Document the release process and checklist in `CONTRIBUTING.md`.
- Add maintenance tests for release workflow, release docs, and the initial `Project.toml` version state.

## Tests

- `git diff --check` - passed
- `julia --project=. -e 'using Test, ToQUIO; include("test/unit/maintenance.jl")'` - passed
- `julia --project=. -e 'using Pkg; Pkg.test()'` - passed, 72 tests
- `julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'` - passed
- `julia --project=docs docs/make.jl --skip-deploy` - passed

Closes #10
