### PR TITLE
Add solver-independent to_quio regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+### Changed
+
+- `to_quio` now validates source models before reformulation: all source variables
+  must be bounded integer or binary variables, affine constraint coefficients and
+  right-hand sides must be integer-valued, equality and inequality rows must be
+  feasible against variable bounds, equality rows must satisfy the integer
+  divisibility condition, and custom constraint penalty hints must be positive.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -133,6 +133,7 @@ const MOI = MathOptInterface
 model = MOI.Utilities.Model{Float64}()
 x = MOI.add_variable(model)
 MOI.add_constraint(model, x, MOI.Interval(0.0, 10.0))
+MOI.add_constraint(model, x, MOI.Integer())
 MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
         MOI.ScalarAffineFunction([MOI.ScalarAffineTerm(1.0, x)], 0.0))
 MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -93,6 +93,15 @@ Core function that performs the QUIO reformulation.
   - `:l`: Lower bounds vector
   - `:u`: Upper bounds vector
 
+**Input validation:**
+- Every source variable must have finite lower and upper bounds and be marked
+  `MOI.Integer` or `MOI.ZeroOne`.
+- Affine constraint coefficients and right-hand sides must be integer-valued.
+- Equality and inequality rows must be feasible within the variable bounds.
+- Equality rows must also pass the integer divisibility check for integer
+  assignments.
+- Custom `ConstraintPenaltyHint` values must be positive.
+
 **Mathematical Formulation:**
 
 The reformulation converts:

--- a/src/to_quio.jl
+++ b/src/to_quio.jl
@@ -49,7 +49,8 @@ function get_variable_bounds(::Type{T}, varmap::Function, source::MOI.ModelLike)
         u[i] = one(T)
     end
 
-    @assert all(!isnothing, l) && all(!isnothing, u) "The model contains unbounded variables."
+    all(!isnothing, l) && all(!isnothing, u) ||
+        error("The model contains unbounded variables.")
 
     return (collect(T, l), collect(T, u))
 end
@@ -207,6 +208,23 @@ function validate_eq_feasibility(::Type{T}, A, b, l, u) where {T}
     for i in eachindex(b)
         δl[i] <= b[i] <= δu[i] ||
             error("Equality constraint $i is infeasible within variable bounds.")
+    end
+
+    validate_eq_integer_feasibility(A, b)
+
+    return nothing
+end
+
+function validate_eq_integer_feasibility(A, b)
+    for i in eachindex(b)
+        row_gcd = BigInt(0)
+        for j in axes(A, 2)
+            row_gcd = gcd(row_gcd, abs(round(BigInt, A[i, j])))
+        end
+
+        row_gcd == 0 && continue
+        rem(round(BigInt, b[i]), row_gcd) == 0 ||
+            error("Equality constraint $i is infeasible over integer assignments.")
     end
 
     return nothing

--- a/src/to_quio.jl
+++ b/src/to_quio.jl
@@ -54,6 +54,27 @@ function get_variable_bounds(::Type{T}, varmap::Function, source::MOI.ModelLike)
     return (collect(T, l), collect(T, u))
 end
 
+function mark_integer_variables!(is_integer::AbstractVector{Bool}, ::Type{S}, varmap::Function, source) where {S}
+    for ci in MOI.get(source, MOI.ListOfConstraintIndices{VI,S}())
+        vi = MOI.get(source, MOI.ConstraintFunction(), ci)
+        is_integer[varmap(vi)] = true
+    end
+
+    return is_integer
+end
+
+function validate_integer_variables(varmap::Function, source::MOI.ModelLike)
+    n = MOI.get(source, MOI.NumberOfVariables())
+    is_integer = falses(n)
+
+    mark_integer_variables!(is_integer, MOI.Integer, varmap, source)
+    mark_integer_variables!(is_integer, MOI.ZeroOne, varmap, source)
+
+    all(is_integer) || error("All source variables must be constrained as Integer or ZeroOne.")
+
+    return nothing
+end
+
 function get_objective_bounds(varmap::Function, f::SAF{T}, l::AbstractVector{T}, u::AbstractVector{T}) where {T}
     δl = zero(T)
     δu = zero(T)
@@ -180,6 +201,28 @@ function get_sensibility(A::AbstractMatrix{T}, b::AbstractVector{T}) where {T}
     end
 end
 
+function validate_eq_feasibility(::Type{T}, A, b, l, u) where {T}
+    δl, δu = get_constraint_bounds(T, A, l, u)
+
+    for i in eachindex(b)
+        δl[i] <= b[i] <= δu[i] ||
+            error("Equality constraint $i is infeasible within variable bounds.")
+    end
+
+    return nothing
+end
+
+function validate_ie_feasibility(::Type{T}, A, b, l, u) where {T}
+    δl, δu = get_constraint_bounds(T, A, l, u)
+
+    for i in eachindex(b)
+        b[i] >= δl[i] ||
+            error("Inequality constraint $i is infeasible within variable bounds.")
+    end
+
+    return (δl, δu)
+end
+
 @doc raw"""
     varmap : VI -> Int
 """
@@ -194,6 +237,7 @@ function to_quio(::Type{T}, varmap::Function, conmap::Function, source::MOI.Mode
     f = MOI.get(source, MOI.ObjectiveFunction{F}())
 
     l, u = get_variable_bounds(T, varmap, source)
+    validate_integer_variables(varmap, source)
 
     n = MOI.get(source, MOI.NumberOfVariables())
 
@@ -214,6 +258,9 @@ function to_quio(::Type{T}, varmap::Function, conmap::Function, source::MOI.Mode
 
     ε_eq = get_sensibility(A_eq, b_eq)
     ε_ie = get_sensibility(A_ie, b_ie)
+
+    validate_eq_feasibility(T, A_eq, b_eq, l, u)
+    cl, _ = validate_ie_feasibility(T, A_ie, b_ie, l, u)
 
     # Compute Penalties!
     # TODO: Store penalties for analysis
@@ -242,7 +289,6 @@ function to_quio(::Type{T}, varmap::Function, conmap::Function, source::MOI.Mode
         (diagm(ρ), diagm(ρ_eq), diagm(ρ_ie))
     end
 
-    cl, cu = get_constraint_bounds(T, A_ie, l, u)
     sb     = b_ie - cl # Calculate slack bounds
 
     x, _ = MOI.add_constrained_variables(target, MOI.Interval{T}.(l, u))
@@ -343,8 +389,28 @@ function get_penalty_hints(::Type{T}, ::Type{F}, ::Type{S}, conmap, source) wher
     for ci in MOI.get(source, MOI.ListOfConstraintIndices{F,S}())
         i = conmap(ci)
 
-        θ[i] = MOI.get(source, ConstraintPenaltyHint(), ci)
+        θ[i] = get_constraint_penalty_hint(T, source, ci)
     end
+
+    return θ
+end
+
+function supports_constraint_penalty_hint(source, ci)
+    return try
+        MOI.supports(source, ConstraintPenaltyHint(), typeof(ci))
+    catch
+        false
+    end
+end
+
+function get_constraint_penalty_hint(::Type{T}, source, ci) where {T}
+    supports_constraint_penalty_hint(source, ci) || return nothing
+
+    θ = MOI.get(source, ConstraintPenaltyHint(), ci)
+    isnothing(θ) && return nothing
+
+    θ = convert(T, θ)
+    θ > zero(T) || error("Constraint penalty hints must be positive.")
 
     return θ
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,6 @@ using ToQUIO
 
 @testset "ToQUIO" begin
     include("unit/maintenance.jl")
+    include("unit/to_quio_regression.jl")
     include("test_examples.jl")
 end

--- a/test/unit/to_quio_regression.jl
+++ b/test/unit/to_quio_regression.jl
@@ -91,6 +91,7 @@ end
 
         @test RMOI.get(target, RMOI.ObjectiveSense()) == RMOI.MIN_SENSE
         @test data[:n] == 1
+        # Δ = 6, ρ = 7; 2x + 1 + ρ(x - 1)^2 gives Q = 7, L = -12, c = 8.
         @test data[:Q] == reshape([7.0], 1, 1)
         @test data[:L] == [-12.0]
         @test data[:c] == 8.0
@@ -108,6 +109,7 @@ end
 
         @test RMOI.get(target, RMOI.ObjectiveSense()) == RMOI.MIN_SENSE
         @test data[:n] == 2
+        # Δ = 3, ρ = 4; x + ρ(x + s - 2)^2 gives Q, L, and c below.
         @test data[:Q] == [4.0 4.0; 4.0 4.0]
         @test data[:L] == [-15.0, -16.0]
         @test data[:c] == 16.0
@@ -124,6 +126,7 @@ end
         _, data = reformulate(source)
 
         @test data[:n] == 2
+        # Δ = 3, ρ = 4; x + ρ(-x + s + 1)^2 gives the canonicalized >= form.
         @test data[:Q] == [4.0 -4.0; -4.0 4.0]
         @test data[:L] == [-7.0, 8.0]
         @test data[:c] == 4.0
@@ -140,6 +143,7 @@ end
         target, data = reformulate(source)
 
         @test RMOI.get(target, RMOI.ObjectiveSense()) == RMOI.MAX_SENSE
+        # Δ = 2, ρ = 3; maximization subtracts the penalty: x - ρ(x - 1)^2.
         @test data[:Q] == reshape([-3.0], 1, 1)
         @test data[:L] == [7.0]
         @test data[:c] == -3.0
@@ -160,6 +164,7 @@ end
         _, data = reformulate(source)
 
         @test data[:n] == 2
+        # No penalties; MOI diagonal quadratic terms are halved, off-diagonal terms are not.
         @test data[:Q] == [3.0 5.0; 0.0 0.0]
         @test data[:L] == [2.0, -1.0]
         @test data[:c] == 4.0
@@ -210,7 +215,7 @@ end
         x = RMOI.add_variable(unbounded)
         RMOI.add_constraint(unbounded, x, RMOI.Integer())
         set_affine_objective!(unbounded, RMOI.MIN_SENSE, affine_term(1, x))
-        @test_throws AssertionError reformulate(unbounded)
+        @test_throws ErrorException reformulate(unbounded)
 
         continuous = RMOI.Utilities.Model{Float64}()
         x = RMOI.add_variable(continuous)
@@ -233,6 +238,16 @@ end
         set_affine_objective!(infeasible_equality, RMOI.MIN_SENSE, affine_term(1, x))
         RMOI.add_constraint(infeasible_equality, affine_function(affine_term(1, x)), RMOI.EqualTo(2.0))
         @test_throws ErrorException reformulate(infeasible_equality)
+
+        integer_infeasible_equality = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(integer_infeasible_equality, 0, 2)
+        set_affine_objective!(integer_infeasible_equality, RMOI.MIN_SENSE, affine_term(1, x))
+        RMOI.add_constraint(
+            integer_infeasible_equality,
+            affine_function(affine_term(2, x)),
+            RMOI.EqualTo(1.0),
+        )
+        @test_throws ErrorException reformulate(integer_infeasible_equality)
 
         infeasible_inequality = RMOI.Utilities.Model{Float64}()
         x = add_interval_integer_variable(infeasible_inequality, 0, 1)

--- a/test/unit/to_quio_regression.jl
+++ b/test/unit/to_quio_regression.jl
@@ -1,0 +1,258 @@
+const RMOI = ToQUIO.MOI
+const SAF64 = RMOI.ScalarAffineFunction{Float64}
+const SQF64 = RMOI.ScalarQuadraticFunction{Float64}
+
+struct HintedModel{T} <: RMOI.ModelLike
+    inner::RMOI.Utilities.Model{T}
+    hints::Dict{Any,T}
+end
+
+RMOI.get(model::HintedModel, attr::ToQUIO.ConstraintPenaltyHint, ci::RMOI.ConstraintIndex) =
+    get(model.hints, ci, nothing)
+
+RMOI.supports(
+    ::HintedModel,
+    ::ToQUIO.ConstraintPenaltyHint,
+    ::Type{<:RMOI.ConstraintIndex},
+) = true
+
+RMOI.get(model::HintedModel, attr::RMOI.AbstractModelAttribute) =
+    RMOI.get(model.inner, attr)
+RMOI.get(model::HintedModel, attr::RMOI.AbstractVariableAttribute, vi::RMOI.VariableIndex) =
+    RMOI.get(model.inner, attr, vi)
+RMOI.get(model::HintedModel, attr::RMOI.AbstractConstraintAttribute, ci::RMOI.ConstraintIndex) =
+    RMOI.get(model.inner, attr, ci)
+
+function affine_term(coefficient, variable)
+    return RMOI.ScalarAffineTerm(Float64(coefficient), variable)
+end
+
+function quadratic_term(coefficient, variable_1, variable_2)
+    return RMOI.ScalarQuadraticTerm(Float64(coefficient), variable_1, variable_2)
+end
+
+function affine_function(terms...; constant = 0.0)
+    return SAF64(collect(terms), Float64(constant))
+end
+
+function quadratic_function(quadratic_terms, affine_terms; constant = 0.0)
+    return SQF64(quadratic_terms, affine_terms, Float64(constant))
+end
+
+function add_interval_integer_variable(model, lower, upper)
+    variable = RMOI.add_variable(model)
+    RMOI.add_constraint(model, variable, RMOI.Interval(Float64(lower), Float64(upper)))
+    RMOI.add_constraint(model, variable, RMOI.Integer())
+    return variable
+end
+
+function add_binary_variable(model)
+    variable = RMOI.add_variable(model)
+    RMOI.add_constraint(model, variable, RMOI.ZeroOne())
+    return variable
+end
+
+function set_affine_objective!(model, sense, terms...; constant = 0.0)
+    RMOI.set(model, RMOI.ObjectiveSense(), sense)
+    RMOI.set(model, RMOI.ObjectiveFunction{SAF64}(), affine_function(terms...; constant))
+    return model
+end
+
+function set_quadratic_objective!(model, sense, quadratic_terms, affine_terms; constant = 0.0)
+    RMOI.set(model, RMOI.ObjectiveSense(), sense)
+    RMOI.set(
+        model,
+        RMOI.ObjectiveFunction{SQF64}(),
+        quadratic_function(quadratic_terms, affine_terms; constant),
+    )
+    return model
+end
+
+function reformulate(model)
+    return ToQUIO.to_quio(Float64, variable -> variable.value, constraint -> constraint.value, model)
+end
+
+function penalized_value(data, z)
+    Q = data[:Q]
+    L = data[:L]
+    quadratic = sum(z[i] * Q[i, j] * z[j] for i in eachindex(z), j in eachindex(z))
+    linear = sum(L[i] * z[i] for i in eachindex(z))
+    return quadratic + linear + data[:c]
+end
+
+@testset "to_quio solver-independent regression tests" begin
+    @testset "linear objective with equality expands penalty" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(source, 0, 3)
+        set_affine_objective!(source, RMOI.MIN_SENSE, affine_term(2, x); constant = 1)
+        RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.EqualTo(1.0))
+
+        target, data = reformulate(source)
+
+        @test RMOI.get(target, RMOI.ObjectiveSense()) == RMOI.MIN_SENSE
+        @test data[:n] == 1
+        @test data[:Q] == reshape([7.0], 1, 1)
+        @test data[:L] == [-12.0]
+        @test data[:c] == 8.0
+        @test data[:l] == [0.0]
+        @test data[:u] == [3.0]
+    end
+
+    @testset "less-than inequality expands slack penalty" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(source, 0, 3)
+        set_affine_objective!(source, RMOI.MIN_SENSE, affine_term(1, x))
+        RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.LessThan(2.0))
+
+        target, data = reformulate(source)
+
+        @test RMOI.get(target, RMOI.ObjectiveSense()) == RMOI.MIN_SENSE
+        @test data[:n] == 2
+        @test data[:Q] == [4.0 4.0; 4.0 4.0]
+        @test data[:L] == [-15.0, -16.0]
+        @test data[:c] == 16.0
+        @test data[:l] == [0.0, 0.0]
+        @test data[:u] == [3.0, 2.0]
+    end
+
+    @testset "greater-than inequality is sign-canonicalized" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(source, 0, 3)
+        set_affine_objective!(source, RMOI.MIN_SENSE, affine_term(1, x))
+        RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.GreaterThan(1.0))
+
+        _, data = reformulate(source)
+
+        @test data[:n] == 2
+        @test data[:Q] == [4.0 -4.0; -4.0 4.0]
+        @test data[:L] == [-7.0, 8.0]
+        @test data[:c] == 4.0
+        @test data[:l] == [0.0, 0.0]
+        @test data[:u] == [3.0, 2.0]
+    end
+
+    @testset "maximization uses negative penalties and max sense" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(source, 0, 2)
+        set_affine_objective!(source, RMOI.MAX_SENSE, affine_term(1, x))
+        RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.EqualTo(1.0))
+
+        target, data = reformulate(source)
+
+        @test RMOI.get(target, RMOI.ObjectiveSense()) == RMOI.MAX_SENSE
+        @test data[:Q] == reshape([-3.0], 1, 1)
+        @test data[:L] == [7.0]
+        @test data[:c] == -3.0
+    end
+
+    @testset "quadratic objective follows MOI coefficient convention" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(source, 0, 2)
+        y = add_interval_integer_variable(source, 0, 3)
+        set_quadratic_objective!(
+            source,
+            RMOI.MIN_SENSE,
+            [quadratic_term(6, x, x), quadratic_term(5, x, y)],
+            [affine_term(2, x), affine_term(-1, y)];
+            constant = 4,
+        )
+
+        _, data = reformulate(source)
+
+        @test data[:n] == 2
+        @test data[:Q] == [3.0 5.0; 0.0 0.0]
+        @test data[:L] == [2.0, -1.0]
+        @test data[:c] == 4.0
+    end
+
+    @testset "binary variables expose binary bounds and integer target variables" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_binary_variable(source)
+        set_affine_objective!(source, RMOI.MIN_SENSE, affine_term(1, x))
+
+        target, data = reformulate(source)
+
+        @test data[:l] == [0.0]
+        @test data[:u] == [1.0]
+        @test RMOI.get(target, RMOI.NumberOfConstraints{RMOI.VariableIndex,RMOI.Integer}()) == 1
+    end
+
+    @testset "automatic penalties prefer feasible optima on small enumerations" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(source, 0, 2)
+        set_affine_objective!(source, RMOI.MIN_SENSE, affine_term(-1, x))
+        RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.LessThan(1.0))
+
+        _, data = reformulate(source)
+
+        best_value = Inf
+        best_x = Int[]
+        for x_value in Int(data[:l][1]):Int(data[:u][1])
+            for slack_value in Int(data[:l][2]):Int(data[:u][2])
+                z = Float64[x_value, slack_value]
+                value = penalized_value(data, z)
+                if value < best_value - 1e-8
+                    best_value = value
+                    empty!(best_x)
+                    push!(best_x, x_value)
+                elseif isapprox(value, best_value; atol = 1e-8)
+                    push!(best_x, x_value)
+                end
+            end
+        end
+
+        @test best_x == [1]
+        @test best_value == -1.0
+    end
+
+    @testset "invalid source models fail before reformulation" begin
+        unbounded = RMOI.Utilities.Model{Float64}()
+        x = RMOI.add_variable(unbounded)
+        RMOI.add_constraint(unbounded, x, RMOI.Integer())
+        set_affine_objective!(unbounded, RMOI.MIN_SENSE, affine_term(1, x))
+        @test_throws AssertionError reformulate(unbounded)
+
+        continuous = RMOI.Utilities.Model{Float64}()
+        x = RMOI.add_variable(continuous)
+        RMOI.add_constraint(continuous, x, RMOI.Interval(0.0, 1.0))
+        set_affine_objective!(continuous, RMOI.MIN_SENSE, affine_term(1, x))
+        @test_throws ErrorException reformulate(continuous)
+
+        noninteger_coefficients = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(noninteger_coefficients, 0, 2)
+        set_affine_objective!(noninteger_coefficients, RMOI.MIN_SENSE, affine_term(1, x))
+        RMOI.add_constraint(
+            noninteger_coefficients,
+            affine_function(affine_term(0.5, x)),
+            RMOI.EqualTo(1.0),
+        )
+        @test_throws ErrorException reformulate(noninteger_coefficients)
+
+        infeasible_equality = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(infeasible_equality, 0, 1)
+        set_affine_objective!(infeasible_equality, RMOI.MIN_SENSE, affine_term(1, x))
+        RMOI.add_constraint(infeasible_equality, affine_function(affine_term(1, x)), RMOI.EqualTo(2.0))
+        @test_throws ErrorException reformulate(infeasible_equality)
+
+        infeasible_inequality = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(infeasible_inequality, 0, 1)
+        set_affine_objective!(infeasible_inequality, RMOI.MIN_SENSE, affine_term(1, x))
+        RMOI.add_constraint(
+            infeasible_inequality,
+            affine_function(affine_term(1, x)),
+            RMOI.LessThan(-1.0),
+        )
+        @test_throws ErrorException reformulate(infeasible_inequality)
+
+        nonpositive_penalty = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(nonpositive_penalty, 0, 2)
+        set_affine_objective!(nonpositive_penalty, RMOI.MIN_SENSE, affine_term(1, x))
+        ci = RMOI.add_constraint(
+            nonpositive_penalty,
+            affine_function(affine_term(1, x)),
+            RMOI.EqualTo(1.0),
+        )
+        hinted = HintedModel(nonpositive_penalty, Dict{Any,Float64}(ci => 0.0))
+        @test_throws ErrorException reformulate(hinted)
+    end
+end


### PR DESCRIPTION
Summary
- Adds solver-independent regression coverage for the `to_quio` reformulation output.
- Covers equality penalties, inequality slack expansion, greater-than canonicalization, maximization penalty sign, MOI quadratic coefficient conventions, binary bounds, and small enumerated equivalence.
- Adds validation for non-integer source variables, infeasible constraint rows, unsupported/missing penalty hints, and nonpositive custom penalty hints.

Tests
- `/home/bernalde/.juliaup/bin/julialauncher +1.10 --project=. -e 'using Test, ToQUIO; const MOI = ToQUIO.MOI; include("test/unit/to_quio_regression.jl")'` - passed, 39 tests.
- `/home/bernalde/.juliaup/bin/julialauncher +1.10 --project=. -e 'using Pkg; Pkg.test()'` - passed, 113 tests.
- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using Pkg; Pkg.test()'` - passed, 113 tests.

Notes
- No separate lint or formatter command is configured in the repository.

Closes #24
