### PR TITLE
Define original result semantics after reformulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   `MOI.ObjectiveValue` returns the original objective evaluated at those mapped
   values. Use `ToQUIO.PenalizedObjectiveValue()` to inspect the backend target
   objective with penalties and slack terms.
+- Optimizer reformulation now maps source variables and constraints by their MOI
+  list positions instead of raw index values, preserving correct target columns
+  and constraint rows for non-contiguous source indices.
 - `to_quio` now validates source models before reformulation: all source variables
   must be bounded integer or binary variables, affine constraint coefficients and
   right-hand sides must be integer-valued, equality and inequality rows must be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- Solver-backed result queries now report original-model semantics:
+  `MOI.VariablePrimal` maps source variables to target variables, and
+  `MOI.ObjectiveValue` returns the original objective evaluated at those mapped
+  values. Use `ToQUIO.PenalizedObjectiveValue()` to inspect the backend target
+  objective with penalties and slack terms.
 - `to_quio` now validates source models before reformulation: all source variables
   must be bounded integer or binary variables, affine constraint coefficients and
   right-hand sides must be integer-valued, equality and inequality rows must be

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -245,7 +245,17 @@ Returns the termination status from the inner solver, or `OPTIMIZE_NOT_CALLED` i
 MOI.get(optimizer::Optimizer, ::MOI.ObjectiveValue)
 ```
 
-Returns the objective value from the inner solver.
+Returns the original source-model objective evaluated at the mapped source
+variable primal values returned by the inner solver.
+
+#### `PenalizedObjectiveValue`
+
+```julia
+MOI.get(optimizer::Optimizer, ToQUIO.PenalizedObjectiveValue())
+```
+
+Returns the objective value reported by the inner solver for the reformulated
+QUIO target model. This includes penalty and slack-variable terms.
 
 #### `MOI.VariablePrimal`
 
@@ -253,7 +263,9 @@ Returns the objective value from the inner solver.
 MOI.get(optimizer::Optimizer, ::MOI.VariablePrimal, vi::VariableIndex)
 ```
 
-Returns the primal value for a variable.
+Returns the primal value for an original source-model variable by mapping it to
+the corresponding target-model variable before querying the inner solver. Slack
+variables introduced by reformulation are not exposed as source variables.
 
 ### Custom Attributes
 

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -25,6 +25,7 @@ function MOI.empty!(solver::Optimizer{T}) where {T}
     isnothing(solver.inner) || MOI.empty!(solver.inner)
     isnothing(solver.source_model) || MOI.empty!(solver.source_model)
     isnothing(solver.target_model) || MOI.empty!(solver.target_model)
+    empty!(solver.data)
 
     return nothing
 end
@@ -33,18 +34,38 @@ include("attributes/model.jl")
 include("attributes/results.jl")
 include("attributes/reformulation.jl")
 
+function _source_variable_positions(source::MOI.ModelLike)
+    return Dict(vi => i for (i, vi) in enumerate(MOI.get(source, MOI.ListOfVariableIndices())))
+end
+
+function _source_constraint_positions(::Type{T}, source::MOI.ModelLike) where {T}
+    constraints = Dict{Any,Int}()
+    for (F, S) in ((SAF{T}, EQ{T}), (SAF{T}, LT{T}), (SAF{T}, GT{T}))
+        for (i, ci) in enumerate(MOI.get(source, MOI.ListOfConstraintIndices{F,S}()))
+            constraints[ci] = i
+        end
+    end
+    return constraints
+end
+
 function MOI.optimize!(solver::Optimizer{T}, model::MOI.ModelLike) where {T}
     solver.source_model = model
+    variable_positions = _source_variable_positions(solver.source_model)
+    constraint_positions = _source_constraint_positions(T, solver.source_model)
 
     solver.target_model, solver.data = to_quio(
         T,
-        vi -> vi.value, # varmap : VI -> Int
-        ci -> ci.value, # conmap : CI{F,S} -> Int
+        vi -> variable_positions[vi], # varmap : VI -> Int
+        ci -> constraint_positions[ci], # conmap : CI{F,S} -> Int
         solver.source_model,
     )
 
     if !isnothing(solver.inner)
-        MOI.optimize!(solver.inner, solver.target_model)
+        index_map, _ = MOI.optimize!(solver.inner, solver.target_model)
+        target_variables = MOI.get(solver.target_model, MOI.ListOfVariableIndices())
+        solver.data[:target_to_backend_variables] = Dict{VI,VI}(
+            vi => index_map[vi] for vi in target_variables
+        )
     end
 
     return (MOIU.identity_index_map(solver.source_model), false)

--- a/src/MOI_wrapper/attributes/results.jl
+++ b/src/MOI_wrapper/attributes/results.jl
@@ -18,6 +18,8 @@ struct PenalizedObjectiveValue <: MOI.AbstractModelAttribute
     PenalizedObjectiveValue(result_index::Int = 1) = new(result_index)
 end
 
+MOI.is_set_by_optimize(::PenalizedObjectiveValue) = true
+
 function _target_variable(solver::Optimizer, vi::VI)
     source_to_target = get(solver.data, :source_to_target_variables, nothing)
     isnothing(source_to_target) &&

--- a/src/MOI_wrapper/attributes/results.jl
+++ b/src/MOI_wrapper/attributes/results.jl
@@ -6,10 +6,37 @@ function MOI.get(solver::Optimizer{T}, attr::MOI.TerminationStatus) where {T}
     end
 end
 
+@doc raw"""
+    PenalizedObjectiveValue(result_index::Int = 1)
+
+Return the objective value reported by the backend on the reformulated QUIO
+target model. `MOI.ObjectiveValue` returns the original objective evaluated at
+the mapped source-variable primal values.
+"""
+struct PenalizedObjectiveValue <: MOI.AbstractModelAttribute
+    result_index::Int
+    PenalizedObjectiveValue(result_index::Int = 1) = new(result_index)
+end
+
+function _target_variable(solver::Optimizer, vi::VI)
+    source_to_target = get(solver.data, :source_to_target_variables, nothing)
+    isnothing(source_to_target) &&
+        error("Variable mappings are unavailable; call optimize! before querying primal values.")
+    haskey(source_to_target, vi) || throw(MOI.InvalidIndex(vi))
+    return source_to_target[vi]
+end
+
+function _backend_variable(solver::Optimizer, vi::VI)
+    target_to_backend = get(solver.data, :target_to_backend_variables, nothing)
+    isnothing(target_to_backend) && return vi
+    haskey(target_to_backend, vi) || throw(MOI.InvalidIndex(vi))
+    return target_to_backend[vi]
+end
+
 function MOI.get(solver::Optimizer{T}, attr::MOI.VariablePrimal, vi::VI) where {T}
     @assert !isnothing(solver.inner)
 
-    return MOI.get(solver.inner, attr, vi) # TODO: Variable mapping
+    return MOI.get(solver.inner, attr, _backend_variable(solver, _target_variable(solver, vi)))
 end
 
 function MOI.supports(solver::Optimizer{T}, attr::MOI.TerminationStatus) where {T}
@@ -18,10 +45,20 @@ end
 
 function MOI.get(solver::Optimizer{T}, attr::MOI.ObjectiveValue) where {T}
     @assert !isnothing(solver.inner)
+    @assert !isnothing(solver.source_model)
 
-    # TODO: Decide what to report: Penalized objective value or Original objective value
+    F = MOI.get(solver.source_model, MOI.ObjectiveFunctionType())
+    f = MOI.get(solver.source_model, MOI.ObjectiveFunction{F}())
 
-    return MOI.get(solver.inner, attr) # This is the penalized one, as passed to the solver
+    return MOIU.eval_variables(solver.source_model, f) do vi
+        return MOI.get(solver, MOI.VariablePrimal(attr.result_index), vi)
+    end
+end
+
+function MOI.get(solver::Optimizer{T}, attr::PenalizedObjectiveValue) where {T}
+    @assert !isnothing(solver.inner)
+
+    return MOI.get(solver.inner, MOI.ObjectiveValue(attr.result_index))
 end
 
 function MOI.get(solver::Optimizer{T}, attr::MOI.ResultCount) where {T}

--- a/src/to_quio.jl
+++ b/src/to_quio.jl
@@ -316,6 +316,10 @@ function to_quio(::Type{T}, varmap::Function, conmap::Function, source::MOI.Mode
     MOI.add_constraints(target, s, MOI.Integer())
 
     z = VI[x; s]
+    source_variables = MOI.get(source, MOI.ListOfVariableIndices())
+    source_to_target_variables = Dict{VI,VI}(
+        vi => x[varmap(vi)] for vi in source_variables
+    )
     
     # Construct Penalty terms
     # F = (x' Q x + ℓ' x + β) + ρ_eq' * (A_eq x - b_eq)' (A_eq x - b_eq) + ρ_ie' * (A_ie x + s - b_ie)' (A_ie x + s - b_ie)
@@ -365,6 +369,10 @@ function to_quio(::Type{T}, varmap::Function, conmap::Function, source::MOI.Mode
         :D => D, #
         :l => T[l; zeros(T, length(s))], # lower
         :u => T[u; sb],                  # upper
+        :source_variables => source_variables,
+        :target_variables => x,
+        :slack_variables => s,
+        :source_to_target_variables => source_to_target_variables,
     )
 
     return (target, data)

--- a/test/unit/to_quio_regression.jl
+++ b/test/unit/to_quio_regression.jl
@@ -80,6 +80,19 @@ function penalized_value(data, z)
     return quadratic + linear + data[:c]
 end
 
+function mock_backend_with_primal(primal)
+    mock = RMOI.Utilities.MockOptimizer(RMOI.Utilities.Model{Float64}())
+    RMOI.Utilities.set_mock_optimize!(
+        mock,
+        mock -> RMOI.Utilities.mock_optimize!(
+            mock,
+            RMOI.OPTIMAL,
+            (RMOI.FEASIBLE_POINT, Float64[primal...]),
+        ),
+    )
+    return mock
+end
+
 @testset "to_quio solver-independent regression tests" begin
     @testset "linear objective with equality expands penalty" begin
         source = RMOI.Utilities.Model{Float64}()
@@ -208,6 +221,30 @@ end
 
         @test best_x == [1]
         @test best_value == -1.0
+    end
+
+    @testset "backend results use original-model semantics" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(source, 0, 3)
+        set_affine_objective!(source, RMOI.MIN_SENSE, affine_term(1, x))
+        RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.LessThan(2.0))
+
+        optimizer = ToQUIO.Optimizer{Float64}(() -> mock_backend_with_primal([3, 0]))
+
+        RMOI.optimize!(optimizer, source)
+
+        @test RMOI.get(optimizer, RMOI.TerminationStatus()) == RMOI.OPTIMAL
+        @test optimizer.data[:source_to_target_variables][x] == RMOI.VariableIndex(1)
+        @test optimizer.data[:target_variables] == [RMOI.VariableIndex(1)]
+        @test optimizer.data[:slack_variables] == [RMOI.VariableIndex(2)]
+        @test RMOI.get(optimizer, RMOI.VariablePrimal(), x) == 3.0
+        @test_throws RMOI.InvalidIndex RMOI.get(
+            optimizer,
+            RMOI.VariablePrimal(),
+            RMOI.VariableIndex(2),
+        )
+        @test RMOI.get(optimizer, RMOI.ObjectiveValue()) == 3.0
+        @test RMOI.get(optimizer, ToQUIO.PenalizedObjectiveValue()) == 7.0
     end
 
     @testset "invalid source models fail before reformulation" begin

--- a/test/unit/to_quio_regression.jl
+++ b/test/unit/to_quio_regression.jl
@@ -234,6 +234,7 @@ end
         RMOI.optimize!(optimizer, source)
 
         @test RMOI.get(optimizer, RMOI.TerminationStatus()) == RMOI.OPTIMAL
+        @test RMOI.is_set_by_optimize(ToQUIO.PenalizedObjectiveValue())
         @test optimizer.data[:source_to_target_variables][x] == RMOI.VariableIndex(1)
         @test optimizer.data[:target_variables] == [RMOI.VariableIndex(1)]
         @test optimizer.data[:slack_variables] == [RMOI.VariableIndex(2)]
@@ -245,6 +246,28 @@ end
         )
         @test RMOI.get(optimizer, RMOI.ObjectiveValue()) == 3.0
         @test RMOI.get(optimizer, ToQUIO.PenalizedObjectiveValue()) == 7.0
+    end
+
+    @testset "backend objective value evaluates quadratic source objective" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(source, 0, 3)
+        y = add_interval_integer_variable(source, 0, 3)
+        set_quadratic_objective!(
+            source,
+            RMOI.MIN_SENSE,
+            [quadratic_term(6, x, x), quadratic_term(5, x, y)],
+            [affine_term(2, x), affine_term(-1, y)];
+            constant = 4,
+        )
+
+        optimizer = ToQUIO.Optimizer{Float64}(() -> mock_backend_with_primal([2, 3]))
+
+        RMOI.optimize!(optimizer, source)
+
+        @test RMOI.get(optimizer, RMOI.VariablePrimal(), x) == 2.0
+        @test RMOI.get(optimizer, RMOI.VariablePrimal(), y) == 3.0
+        @test RMOI.get(optimizer, RMOI.ObjectiveValue()) == 47.0
+        @test RMOI.get(optimizer, ToQUIO.PenalizedObjectiveValue()) == 47.0
     end
 
     @testset "invalid source models fail before reformulation" begin


### PR DESCRIPTION
## Summary

- Map source variables to target variables during reformulation and compose the backend copy map when querying solver results.
- Make `MOI.ObjectiveValue` return the original source objective evaluated at mapped source-variable primal values.
- Add `ToQUIO.PenalizedObjectiveValue()` for the backend reformulated objective with penalties and slack terms.
- Document the result semantics and add regression coverage for variable mapping, slack isolation, and original vs penalized objective values.

Closes #25

## Tests

- `/home/bernalde/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia --project=. -e 'using Test, ToQUIO; include("test/unit/to_quio_regression.jl")'`
- `/home/bernalde/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia --project=. -e 'using Pkg; Pkg.test()'`
- `/home/bernalde/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/bin/julia --project=. -e 'using Pkg; Pkg.test()'`
- `/home/bernalde/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`
- `/home/bernalde/.julia/juliaup/julia-1.12.6+0.x64.linux.gnu/bin/julia --project=docs docs/make.jl --skip-deploy`

## Notes

- The first docs build attempt failed because the local ignored `docs/Manifest.toml` was stale for Julia 1.12 and referenced `MbedTLS_jll`; refreshing the docs environment with the CI setup command resolved it.
