### PR TITLE
Validate penalty hints and clarify penalty math

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,9 +95,9 @@ const CI{F,S} = MOI.ConstraintIndex{F,S}
 # Priority: user-defined hints over auto-calculated penalties
 # θ (theta): user-defined penalty hints (Maybe{T} vector)
 # Δ (Delta): objective delta (bound difference)
-# ε (epsilon): constraint sensitivity
+# ε (epsilon): minimum nonzero constraint violation magnitude
 # ϵ (epsilon_tolerance): epsilon tolerance
-ρ = something.(θ, (Δ ./ ε) .+ ϵ)
+ρ = something.(θ, (Δ ./ (ε .^ 2)) .+ ϵ)
 ```
 
 ## Development Guidelines

--- a/docs/src/QUICKSTART.md
+++ b/docs/src/QUICKSTART.md
@@ -78,7 +78,7 @@ println("Reformulated variables: ", data[:n])
 See `to_quio.jl`:
 - `get_objective_delta()`: Computes objective range
 - `get_sensibility()`: Constraint violation granularity  
-- Lines ~210-214: Actual penalty computation `ρ = Δ/ε + ϵ`
+- Lines ~280-290: Actual automatic penalty computation `ρ = Δ/ε² + ϵ`
 
 #### Debugging reformulation
 
@@ -150,11 +150,11 @@ Where `z = [x; s]` includes slack variables for inequalities.
 ### Penalty Coefficients
 
 ```julia
-ρ = Δ/ε + ϵ
+ρ = Δ/ε² + ϵ
 ```
 
-- `Δ`: Objective function range over feasible region
-- `ε`: Minimum constraint violation (sensibility)
+- `Δ`: Objective function range bound over variable bounds
+- `ε`: Minimum nonzero constraint violation magnitude (sensibility)
 - `ϵ`: User adjustment (default: 1.0)
 
 ## Type System

--- a/docs/src/algorithm.md
+++ b/docs/src/algorithm.md
@@ -179,8 +179,9 @@ MOI.set(model, ConstraintPenaltyHint(), constraint, custom_penalty)
 Custom penalty hints must be finite and positive. They override the automatic
 sufficient coefficient and are treated as user-chosen heuristic values; if a
 hint is lower than `ρ_auto`, ToQUIO uses it but equivalence to the constrained
-problem is not guaranteed. The reformulation metadata stores the selected
-penalties, automatic penalties, and user hints for inspection.
+problem is not guaranteed. ToQUIO emits a warning when a hint is below
+`ρ_auto`. The reformulation metadata stores the selected penalties, automatic
+penalties, user hints, and corresponding source constraints for inspection.
 
 ## Reformulation Steps
 

--- a/docs/src/algorithm.md
+++ b/docs/src/algorithm.md
@@ -120,23 +120,28 @@ The penalty coefficients must be large enough to enforce constraints but not so 
 
 ### Objective Range
 
-First, compute the range of the objective function over the feasible region defined by bounds:
+First, compute an objective range bound over the region defined by variable bounds:
 
 ```
-Δ = max{f(x) : l ≤ x ≤ u} - min{f(x) : l ≤ x ≤ u}
+Δ_bound ≥ max{f(x) : l ≤ x ≤ u} - min{f(x) : l ≤ x ≤ u}
 ```
 
-For linear objectives `f(x) = ℓ'x + β`:
+For linear objectives `f(x) = ℓ'x + β`, this bound is exact:
 
 ```
-Δ = Σᵢ |ℓᵢ|(uᵢ - lᵢ)
+Δ_bound = Σᵢ |ℓᵢ|(uᵢ - lᵢ)
 ```
 
-For quadratic objectives, the computation is more complex (see implementation).
+For quadratic objectives, ToQUIO computes a conservative termwise interval
+bound by summing the minimum and maximum contribution of each affine and
+quadratic objective term over the variable bounds. This can overestimate the
+exact objective range because each term is bounded independently.
 
 ### Sensibility Factor
 
-For constraint `Ax ⊙ b` (where ⊙ is =, ≤, or ≥), the sensibility factor `ε` represents the minimum violation granularity. For integer coefficients:
+For constraint `Ax ⊙ b` (where ⊙ is =, ≤, or ≥), the sensibility factor `ε`
+represents the minimum nonzero violation magnitude. The current implementation
+requires integer-valued constraint coefficients and right-hand sides, so:
 
 ```
 ε = 1
@@ -146,18 +151,22 @@ This ensures that any violation is at least 1 in magnitude.
 
 ### Penalty Formula
 
-The penalty coefficient for each constraint is computed as:
+The automatic penalty coefficient for each constraint is computed as:
 
 ```
-ρ = Δ/ε + ϵ
+ρ_auto = Δ_bound/ε² + ϵ
 ```
 
 Where:
-- `Δ`: Objective range
-- `ε`: Sensibility factor
+- `Δ_bound`: Exact objective range for affine objectives, or a conservative
+  objective range bound for quadratic objectives
+- `ε`: Minimum nonzero violation magnitude
 - `ϵ`: User-specified adjustment (default: 1.0)
 
-This ensures that any constraint violation causes an objective increase larger than the entire objective range, strongly incentivizing feasibility.
+Because the penalty term is quadratic, a minimum nonzero violation contributes
+`ρ_auto * ε²`. With positive `ϵ`, the automatic coefficient makes that
+contribution larger than the objective range bound, strongly incentivizing
+feasibility.
 
 ### User-Specified Penalties
 
@@ -166,6 +175,12 @@ Users can override automatic penalties using the `ConstraintPenaltyHint` attribu
 ```julia
 MOI.set(model, ConstraintPenaltyHint(), constraint, custom_penalty)
 ```
+
+Custom penalty hints must be finite and positive. They override the automatic
+sufficient coefficient and are treated as user-chosen heuristic values; if a
+hint is lower than `ρ_auto`, ToQUIO uses it but equivalence to the constrained
+problem is not guaranteed. The reformulation metadata stores the selected
+penalties, automatic penalties, and user hints for inspection.
 
 ## Reformulation Steps
 
@@ -179,11 +194,11 @@ MOI.set(model, ConstraintPenaltyHint(), constraint, custom_penalty)
 
 ### Step 2: Compute Penalties
 
-1. Compute objective range `Δ`
+1. Compute objective range bound `Δ_bound`
 2. Compute sensibility factors `ε_eq`, `ε_ie`
 3. Compute penalty coefficients:
-   - `ρ_eq = Δ/ε_eq + ϵ` for equalities
-   - `ρ_ie = Δ/ε_ie + ϵ` for inequalities
+   - `ρ_auto_eq = Δ_bound/ε_eq² + ϵ` for equalities
+   - `ρ_auto_ie = Δ_bound/ε_ie² + ϵ` for inequalities
 4. Apply user hints if provided
 
 ### Step 3: Add Slack Variables

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -89,7 +89,13 @@ Core function that performs the QUIO reformulation.
   - `:Q`: Quadratic term matrix
   - `:L`: Linear term vector
   - `:c`: Constant term
-  - `:D`: Diagonal penalty matrix
+  - `:D`: Diagonal penalty matrix used in the target objective, including the
+    objective-sense sign
+  - `:rho`: Selected positive penalty coefficients before applying the
+    objective-sense sign
+  - `:rho_auto`: Automatic sufficient positive penalty coefficients
+  - `:penalty_hints`: User-provided penalty hints, or `nothing` for automatic
+    penalties
   - `:l`: Lower bounds vector
   - `:u`: Upper bounds vector
 
@@ -100,7 +106,7 @@ Core function that performs the QUIO reformulation.
 - Equality and inequality rows must be feasible within the variable bounds.
 - Equality rows must also pass the integer divisibility check for integer
   assignments.
-- Custom `ConstraintPenaltyHint` values must be positive.
+- Custom `ConstraintPenaltyHint` values must be finite and positive.
 
 **Mathematical Formulation:**
 
@@ -275,7 +281,10 @@ variables introduced by reformulation are not exposed as source variables.
 struct ConstraintPenaltyHint <: MOI.AbstractConstraintAttribute end
 ```
 
-Allows users to specify custom penalty coefficients for constraints.
+Allows users to specify custom penalty coefficients for constraints. Hints must
+be finite and positive. They override the automatic sufficient coefficient, so
+small hints are treated as heuristic values and may not preserve equivalence to
+the constrained source problem.
 
 **Usage:**
 
@@ -303,10 +312,12 @@ These functions are used internally and are not part of the public API, but may 
 get_objective_delta(varmap::Function, f, l::AbstractVector{T}, u::AbstractVector{T}) where {T}
 ```
 
-Computes the objective value range based on variable bounds.
+Computes the objective value range based on variable bounds. This is exact for
+affine objectives. For quadratic objectives, it is a conservative termwise
+interval bound and may overestimate the exact range.
 
 **Returns:**
-- `Δ = δ_max - δ_min`: Objective range
+- `Δ = δ_max - δ_min`: Objective range or range bound
 
 ### Constraint Bounds
 
@@ -331,7 +342,8 @@ Computes sensibility factors for penalty computation.
 - `ε`: Vector of sensibility factors
 
 **Requirements:**
-- Currently requires integer coefficients
+- Currently requires integer-valued constraint coefficients and right-hand
+  sides, which makes `ε = 1`
 
 ## Type Aliases
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -96,6 +96,9 @@ Core function that performs the QUIO reformulation.
   - `:rho_auto`: Automatic sufficient positive penalty coefficients
   - `:penalty_hints`: User-provided penalty hints, or `nothing` for automatic
     penalties
+  - `:penalty_constraints`: Source constraint indices corresponding to
+    `:rho`, `:rho_auto`, and `:penalty_hints`, ordered as equalities,
+    less-than inequalities, then greater-than inequalities
   - `:l`: Lower bounds vector
   - `:u`: Upper bounds vector
 
@@ -284,7 +287,8 @@ struct ConstraintPenaltyHint <: MOI.AbstractConstraintAttribute end
 Allows users to specify custom penalty coefficients for constraints. Hints must
 be finite and positive. They override the automatic sufficient coefficient, so
 small hints are treated as heuristic values and may not preserve equivalence to
-the constrained source problem.
+the constrained source problem. ToQUIO emits a warning when a hint is below the
+automatic sufficient coefficient.
 
 **Usage:**
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -330,6 +330,7 @@ display(optimizer.data[:D])
 println("Selected penalties: ", optimizer.data[:rho])
 println("Automatic penalties: ", optimizer.data[:rho_auto])
 println("User hints: ", optimizer.data[:penalty_hints])
+println("Penalty constraints: ", optimizer.data[:penalty_constraints])
 ```
 
 ## Working with Different Solvers

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -318,16 +318,18 @@ model = Model(() -> optimizer)
 @constraint(model, c1, x + y >= 5)
 @constraint(model, c2, x - y == 0)
 
-# Set custom penalty for equality constraint (make it very strict)
+# Set finite, positive custom penalties.
+# These override automatic sufficient penalties and can be heuristic.
 MOI.set(backend(model), ToQUIO.ConstraintPenaltyHint(), index(c2), 1000.0)
-
-# Set custom penalty for inequality (more lenient)
 MOI.set(backend(model), ToQUIO.ConstraintPenaltyHint(), index(c1), 10.0)
 
 optimize!(model)
 
 println("Penalty matrix:")
 display(optimizer.data[:D])
+println("Selected penalties: ", optimizer.data[:rho])
+println("Automatic penalties: ", optimizer.data[:rho_auto])
+println("User hints: ", optimizer.data[:penalty_hints])
 ```
 
 ## Working with Different Solvers

--- a/src/to_quio.jl
+++ b/src/to_quio.jl
@@ -281,11 +281,14 @@ function to_quio(::Type{T}, varmap::Function, conmap::Function, source::MOI.Mode
     cl, _ = validate_ie_feasibility(T, A_ie, b_ie, l, u)
 
     # Compute Penalties!
-    # TODO: Store penalties for analysis
     # NOTE: This gives priority to user-defined penalties.
-    ρ_eq = something.(θ_eq, (Δ ./ ε_eq) .+ ϵ)
-    ρ_ie = something.(θ_ie, (Δ ./ ε_ie) .+ ϵ)
+    ρ_auto_eq = (Δ ./ (ε_eq .^ 2)) .+ ϵ
+    ρ_auto_ie = (Δ ./ (ε_ie .^ 2)) .+ ϵ
+    ρ_eq = something.(θ_eq, ρ_auto_eq)
+    ρ_ie = something.(θ_ie, ρ_auto_ie)
     ρ    = T[ρ_eq; ρ_ie]
+    ρ_auto = T[ρ_auto_eq; ρ_auto_ie]
+    θ = Maybe{T}[θ_eq; θ_ie]
 
     target = QUIOModel{T}()
 
@@ -367,6 +370,9 @@ function to_quio(::Type{T}, varmap::Function, conmap::Function, source::MOI.Mode
         :L => g, # linear terms
         :c => γ, # constant term
         :D => D, #
+        :rho => ρ,
+        :rho_auto => ρ_auto,
+        :penalty_hints => θ,
         :l => T[l; zeros(T, length(s))], # lower
         :u => T[u; sb],                  # upper
         :source_variables => source_variables,
@@ -436,7 +442,8 @@ function get_constraint_penalty_hint(::Type{T}, source, ci) where {T}
     isnothing(θ) && return nothing
 
     θ = convert(T, θ)
-    θ > zero(T) || error("Constraint penalty hints must be positive.")
+    isfinite(θ) && θ > zero(T) ||
+        error("Constraint penalty hints must be finite and positive.")
 
     return θ
 end

--- a/src/to_quio.jl
+++ b/src/to_quio.jl
@@ -284,11 +284,16 @@ function to_quio(::Type{T}, varmap::Function, conmap::Function, source::MOI.Mode
     # NOTE: This gives priority to user-defined penalties.
     ρ_auto_eq = (Δ ./ (ε_eq .^ 2)) .+ ϵ
     ρ_auto_ie = (Δ ./ (ε_ie .^ 2)) .+ ϵ
-    ρ_eq = something.(θ_eq, ρ_auto_eq)
-    ρ_ie = something.(θ_ie, ρ_auto_ie)
+    ρ_eq = apply_penalty_hints(θ_eq, ρ_auto_eq, :equality)
+    ρ_ie = apply_penalty_hints(θ_ie, ρ_auto_ie, :inequality)
     ρ    = T[ρ_eq; ρ_ie]
     ρ_auto = T[ρ_auto_eq; ρ_auto_ie]
     θ = Maybe{T}[θ_eq; θ_ie]
+    penalty_constraints = Any[
+        get_eq_constraint_indices(T, conmap, source);
+        get_lt_constraint_indices(T, conmap, source);
+        get_gt_constraint_indices(T, conmap, source);
+    ]
 
     target = QUIOModel{T}()
 
@@ -373,6 +378,7 @@ function to_quio(::Type{T}, varmap::Function, conmap::Function, source::MOI.Mode
         :rho => ρ,
         :rho_auto => ρ_auto,
         :penalty_hints => θ,
+        :penalty_constraints => penalty_constraints,
         :l => T[l; zeros(T, length(s))], # lower
         :u => T[u; sb],                  # upper
         :source_variables => source_variables,
@@ -448,9 +454,44 @@ function get_constraint_penalty_hint(::Type{T}, source, ci) where {T}
     return θ
 end
 
+function apply_penalty_hints(θ::AbstractVector{Maybe{T}}, ρ_auto::AbstractVector{T}, constraint_kind::Symbol) where {T}
+    ρ = similar(ρ_auto)
+
+    for i in eachindex(ρ_auto)
+        hint = θ[i]
+
+        if isnothing(hint)
+            ρ[i] = ρ_auto[i]
+        else
+            if hint < ρ_auto[i]
+                @warn "Constraint penalty hint is below the automatic sufficient penalty; constrained-problem equivalence is not guaranteed." constraint_kind=constraint_kind constraint_index=i hint=hint automatic_penalty=ρ_auto[i]
+            end
+
+            ρ[i] = hint
+        end
+    end
+
+    return ρ
+end
+
 get_eq_penalty_hints(::Type{T}, conmap, source) where {T} = get_penalty_hints(T, SAF{T}, EQ{T}, conmap, source)
 get_lt_penalty_hints(::Type{T}, conmap, source) where {T} = get_penalty_hints(T, SAF{T}, LT{T}, conmap, source)
 get_gt_penalty_hints(::Type{T}, conmap, source) where {T} = get_penalty_hints(T, SAF{T}, GT{T}, conmap, source)
+
+function get_constraint_indices(::Type{T}, ::Type{F}, ::Type{S}, conmap, source) where {T,F,S}
+    m = MOI.get(source, MOI.NumberOfConstraints{F,S}())
+    indices = Vector{CI{F,S}}(undef, m)
+
+    for ci in MOI.get(source, MOI.ListOfConstraintIndices{F,S}())
+        indices[conmap(ci)] = ci
+    end
+
+    return indices
+end
+
+get_eq_constraint_indices(::Type{T}, conmap, source) where {T} = get_constraint_indices(T, SAF{T}, EQ{T}, conmap, source)
+get_lt_constraint_indices(::Type{T}, conmap, source) where {T} = get_constraint_indices(T, SAF{T}, LT{T}, conmap, source)
+get_gt_constraint_indices(::Type{T}, conmap, source) where {T} = get_constraint_indices(T, SAF{T}, GT{T}, conmap, source)
 
 function get_lt_matrices(::Type{T}, varmap::Function, conmap::Function, source) where {T}
     F = SAF{T}

--- a/test/unit/to_quio_regression.jl
+++ b/test/unit/to_quio_regression.jl
@@ -98,7 +98,7 @@ end
         source = RMOI.Utilities.Model{Float64}()
         x = add_interval_integer_variable(source, 0, 3)
         set_affine_objective!(source, RMOI.MIN_SENSE, affine_term(2, x); constant = 1)
-        RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.EqualTo(1.0))
+        ci = RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.EqualTo(1.0))
 
         target, data = reformulate(source)
 
@@ -111,6 +111,7 @@ end
         @test data[:rho] == [7.0]
         @test data[:rho_auto] == [7.0]
         @test data[:penalty_hints] == [nothing]
+        @test data[:penalty_constraints] == Any[ci]
         @test data[:l] == [0.0]
         @test data[:u] == [3.0]
     end
@@ -122,12 +123,32 @@ end
         ci = RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.EqualTo(1.0))
 
         hinted = HintedModel(source, Dict{Any,Float64}(ci => 2.0))
-        _, data = reformulate(hinted)
+        _, data = @test_logs (
+            :warn,
+            r"Constraint penalty hint is below the automatic sufficient penalty",
+        ) reformulate(hinted)
 
         @test data[:rho_auto] == [3.0]
         @test data[:rho] == [2.0]
         @test data[:penalty_hints] == [2.0]
+        @test data[:penalty_constraints] == Any[ci]
         @test data[:D] == reshape([2.0], 1, 1)
+    end
+
+    @testset "penalty metadata records source constraints in reformulation order" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(source, 0, 3)
+        set_affine_objective!(source, RMOI.MIN_SENSE, affine_term(1, x))
+        ci_lt = RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.LessThan(2.0))
+        ci_eq = RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.EqualTo(1.0))
+        ci_gt = RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.GreaterThan(0.0))
+
+        _, data = reformulate(source)
+
+        @test data[:penalty_constraints] == Any[ci_eq, ci_lt, ci_gt]
+        @test length(data[:rho]) == length(data[:penalty_constraints])
+        @test length(data[:rho_auto]) == length(data[:penalty_constraints])
+        @test length(data[:penalty_hints]) == length(data[:penalty_constraints])
     end
 
     @testset "less-than inequality expands slack penalty" begin

--- a/test/unit/to_quio_regression.jl
+++ b/test/unit/to_quio_regression.jl
@@ -108,8 +108,26 @@ end
         @test data[:Q] == reshape([7.0], 1, 1)
         @test data[:L] == [-12.0]
         @test data[:c] == 8.0
+        @test data[:rho] == [7.0]
+        @test data[:rho_auto] == [7.0]
+        @test data[:penalty_hints] == [nothing]
         @test data[:l] == [0.0]
         @test data[:u] == [3.0]
+    end
+
+    @testset "penalty hints override automatic penalties and are recorded" begin
+        source = RMOI.Utilities.Model{Float64}()
+        x = add_interval_integer_variable(source, 0, 2)
+        set_affine_objective!(source, RMOI.MIN_SENSE, affine_term(1, x))
+        ci = RMOI.add_constraint(source, affine_function(affine_term(1, x)), RMOI.EqualTo(1.0))
+
+        hinted = HintedModel(source, Dict{Any,Float64}(ci => 2.0))
+        _, data = reformulate(hinted)
+
+        @test data[:rho_auto] == [3.0]
+        @test data[:rho] == [2.0]
+        @test data[:penalty_hints] == [2.0]
+        @test data[:D] == reshape([2.0], 1, 1)
     end
 
     @testset "less-than inequality expands slack penalty" begin
@@ -327,7 +345,9 @@ end
             affine_function(affine_term(1, x)),
             RMOI.EqualTo(1.0),
         )
-        hinted = HintedModel(nonpositive_penalty, Dict{Any,Float64}(ci => 0.0))
-        @test_throws ErrorException reformulate(hinted)
+        for invalid_penalty in (0.0, -1.0, Inf, NaN)
+            hinted = HintedModel(nonpositive_penalty, Dict{Any,Float64}(ci => invalid_penalty))
+            @test_throws ErrorException reformulate(hinted)
+        end
     end
 end


### PR DESCRIPTION
Summary
- Reject custom constraint penalty hints unless they are finite and positive.
- Compute automatic penalty coefficients with the quadratic-penalty scaling `Delta / epsilon^2 + epsilon_tolerance`.
- Store selected penalties, automatic penalties, and user hints in reformulation metadata for inspection.
- Clarify the docs around conservative quadratic objective range bounds, current integer sensibility, and heuristic user penalty hints.

Tests
- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using Test, ToQUIO; include("test/unit/to_quio_regression.jl")'` - 63 passed.
- `/home/bernalde/.juliaup/bin/julialauncher +release --project=. -e 'using Pkg; Pkg.test()'` - 137 passed.
- `/home/bernalde/.juliaup/bin/julialauncher +release --project=docs docs/make.jl --skip-deploy` - passed.

Notes
- No separate lint, type-check, or formatter command is documented for this repository.

Closes #23
