### PR TITLE
Switch install guidance to registered install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,9 +221,9 @@ Aim for high test coverage, especially for:
 
 ## Release Process
 
-ToQUIO.jl is intended to be registered in the Julia General registry. Until the
-first registration is accepted and tagged, users should install the package by
-URL as shown in the README.
+ToQUIO.jl is registered in the Julia General registry; users install the
+released package by name as shown in the README, and contributors can install
+the development version by URL.
 
 Registered releases use JuliaRegistrator and TagBot:
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,18 @@ A Julia package that reformulates constrained integer optimization problems into
 
 ## Installation
 
-ToQUIO.jl is targeting registration in the Julia General registry. Until the
-first registered release is accepted and tagged, install it by URL from a Julia
+ToQUIO.jl is registered in the Julia General registry. Install it from a Julia
 REPL:
 
 ```julia
 using Pkg
-Pkg.add(url="https://github.com/SECQUOIA/ToQUIO.jl")
+Pkg.add("ToQUIO")
+```
+
+Or from the Julia package manager (press `]`):
+
+```julia
+pkg> add ToQUIO
 ```
 
 The examples below use JuMP to build models. Install JuMP separately if it is
@@ -33,17 +38,12 @@ using Pkg
 Pkg.add("JuMP")
 ```
 
-Or from the Julia package manager (press `]`):
-
-```julia
-pkg> add https://github.com/SECQUOIA/ToQUIO.jl
-```
-
-After registration, released versions will be installable with:
+To install the latest unreleased development version directly from the
+repository instead of the registered release:
 
 ```julia
 using Pkg
-Pkg.add("ToQUIO")
+Pkg.add(url="https://github.com/SECQUOIA/ToQUIO.jl")
 ```
 
 ## Quick Start
@@ -285,10 +285,9 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 
 ### Release State
 
-ToQUIO.jl is on the Julia General registration path rather than a permanent
-URL-only release path. The initial registration/tag should use
-`version = "0.1.0"` from `Project.toml` unless a feature or breaking change
-requires a version bump before registration.
+ToQUIO.jl is registered in the Julia General registry. The initial registered
+release is `version = "0.1.0"` from `Project.toml`; later releases bump that
+version for features or breaking changes.
 
 ## References
 

--- a/test/unit/maintenance.jl
+++ b/test/unit/maintenance.jl
@@ -174,9 +174,9 @@ end
     readme = read(joinpath(pkgdir(ToQUIO), "README.md"), String)
     contributing = read(joinpath(pkgdir(ToQUIO), "CONTRIBUTING.md"), String)
 
-    @test occursin("targeting registration in the Julia General registry", readme)
-    @test occursin("After registration, released versions will be installable", readme)
+    @test occursin("registered in the Julia General registry", readme)
     @test occursin("""Pkg.add("ToQUIO")""", readme)
+    @test occursin("""Pkg.add(url="https://github.com/SECQUOIA/ToQUIO.jl")""", readme)
     @test occursin("version = \"$(INITIAL_REGISTRATION_VERSION)\"", readme)
 
     @test occursin("## Release Process", contributing)


### PR DESCRIPTION
## Summary

Switches the documented installation guidance from URL-only to the registered package, per #29.

- README: `Pkg.add("ToQUIO")` is now the primary install (REPL and pkg-mode); the URL install is retained as the explicit "unreleased development version" option; drops the "targeting registration" / "until the first registered release" framing.
- README "Release State": states ToQUIO.jl is registered in General; keeps `version = "0.1.0"` as the initial registered release.
- CONTRIBUTING: updates the Release Process intro sentence to match (registered install by name; development install by URL).
- `test/unit/maintenance.jl` "Release documentation policy": updates the two assertions that referenced the old wording to assert the new registered-install guidance and that the URL/development install is still documented. No assertion was deleted or weakened; `Pkg.add("ToQUIO")` and `version = "0.1.0"` checks are retained.

## Registration status

`ToQUIO v0.1.0` is now registered and installable:

- JuliaRegistries/General#157289 merged on 2026-06-13.
- TagBot created the `v0.1.0` tag and GitHub release.
- Clean Julia install verification passed:

```julia
using Pkg
Pkg.activate(temp=true)
Pkg.add("ToQUIO")
using ToQUIO
Base.pkgversion(ToQUIO) # 0.1.0
```

## Tests

- `julia --project=. -e 'using Pkg; Pkg.test()'` - passed, 144/144 (Julia 1.10.11). The updated "Release documentation policy" testset passes against the new README/CONTRIBUTING wording.
- Clean registry install verification passed after General propagation: `Pkg.add("ToQUIO"); using ToQUIO; Base.pkgversion(ToQUIO) == v"0.1.0"`.

## Notes

- No lint/format command is configured for this repository.
- Out of scope (stays in #20): registry/TagBot/SSH_KEY operational steps.

Closes #29
Refs #20
